### PR TITLE
Add hmac selection to PowerShell command

### DIFF
--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -73,6 +73,11 @@ you should be able to connect to the login nodes using the following command, re
 ssh k1234567@hpc.create.kcl.ac.uk
 ```
 
+When using PowerShell on Windows, you might see the error message “Corrupted MAC on input.” In this case, use the following command instead:
+```bash
+ssh -m hmac-sha2-512 k1234567@hpc.create.kcl.ac.uk
+```
+
 You should see something similar to
 
 ```text


### PR DESCRIPTION
A few learners ran into this issue during today’s training. We have this [mentioned in the docs](https://docs.er.kcl.ac.uk/CREATE/access/#connecting-to-create-hpc-using-ssh-on-windows) already, but it is important enough to be included in the course materials directly.

I have no access to Windows so could not fully nail down whether this is specific to PowerShell; but I don’t remember ever encountering this in SWC trainings (where we typically used git-bash or WSL), so it does not appear to be an issue there.